### PR TITLE
Remove the experimental wasm flag as it is only required for nodev14

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "scripts": {
-    "test": "node --experimental-wasm-bigint node_modules/mocha/bin/_mocha --timeout 100000"
+    "test": "node node_modules/mocha/bin/_mocha --timeout 1000000"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Signed-off-by: Jinank Jain <jinank94@gmail.com>