### PR TITLE
Convert input from bytes to bits following circomlib's sha256 circuit

### DIFF
--- a/circuits/aes_256_ctr.circom
+++ b/circuits/aes_256_ctr.circom
@@ -4,64 +4,58 @@ pragma circom 2.0.0;
 include "aes_256_encrypt.circom";
 include "helper_functions.circom";
 
-template AES256CTR(msg_len)
+template AES256CTR(n_bits)
 {
-    signal input in[msg_len];
-    signal input ctr[4];
-    signal input ks[60];
-    signal output out[msg_len];
+    var msg_len = n_bits/8;
+    signal input in[n_bits];
+    signal input ctr[128];
+    signal input ks[1920];
+    signal output out[n_bits];
 
-    var EK[4];
+    var EK[128];
     var p_index = 0, c_index = 0;
-    var ctr_t[4] = ctr;
+    var ctr_t[128] = ctr;
     var out_t[msg_len][8];
 
     var i, j, k, l;
 
-    component num2bits_1[msg_len];
-    for(i=0; i<msg_len; i++)
-    {
-        num2bits_1[i] = Num2Bits(8);
-        num2bits_1[i].in <== in[i];
-    }
-
     component aes_256_encrypt_1[msg_len/16];
-    component num2bits_2[msg_len/16][4];
     component xor_1[msg_len/16][4][4][32];
+    component num2bits_1[msg_len/16];
+    component bits2num_1[msg_len/16];
 
     for(i=0; i<msg_len/16; i++)
     {
         aes_256_encrypt_1[i] = AES256Encrypt();
-        for(j=0; j<4; j++) aes_256_encrypt_1[i].in[j] <== ctr_t[j];
-        for(j=0; j<60; j++) aes_256_encrypt_1[i].ks[j] <== ks[j];
+        for(j=0; j<128; j++) aes_256_encrypt_1[i].in[j] <== ctr_t[j];
+        for(j=0; j<1920; j++) aes_256_encrypt_1[i].ks[j] <== ks[j];
 
         EK = aes_256_encrypt_1[i].out;
 
         for(j=0; j<4; j++)
         {
-            num2bits_2[i][j] = Num2Bits(32);
-            num2bits_2[i][j].in <== EK[j];
-
             for(k=0; k<4; k++)
             {
                 for(l=0; l<8; l++)
                 {
                     xor_1[i][j][k][l] = XOR();
-                    xor_1[i][j][k][l].a <== num2bits_1[i*16+j*4+k].out[l];
-                    xor_1[i][j][k][l].b <== num2bits_2[i][j].out[k*8+l];
+                    xor_1[i][j][k][l].a <== in[i*128+j*32+k*8+l];
+                    xor_1[i][j][k][l].b <== EK[j*32+k*8+l];
 
-                    out_t[i*16+j*4+k][l] = xor_1[i][j][k][l].out;
+                    out[i*128+j*32+k*8+l] <== xor_1[i][j][k][l].out;
                 }
             }
         }
-        ctr_t[0] += 1;
-    }
-
-    component bits2num_1[msg_len];
-    for(i=0; i<msg_len; i++)
-    {
-        bits2num_1[i] = Bits2Num(8);
-        for(j=0; j<8; j++) bits2num_1[i].in[j] <== out_t[i][j];
-        out[i] <== bits2num_1[i].out;
+        bits2num_1[i] = Bits2Num(32);
+        num2bits_1[i] = Num2Bits(32);
+        for(j=0; j<4; j++) 
+        {
+            for(k=0; k<8; k++) bits2num_1[i].in[j*8+k] <== ctr_t[j*8+7-k];
+        }
+        num2bits_1[i].in <== bits2num_1[i].out + 1;
+        for(j=0; j<4; j++)
+        {
+            for(k=0; k<8; k++) ctr_t[j*8+k] = num2bits_1[i].out[j*8+7-k];
+        }
     }
 }

--- a/circuits/aes_256_encrypt.circom
+++ b/circuits/aes_256_encrypt.circom
@@ -7,31 +7,24 @@ include "helper_functions.circom";
 
 template AES256Encrypt()
 {
-    signal input in[4];
-    signal input ks[60];
-    signal output out[4];
+    signal input in[128];
+    signal input ks[1920];
+    signal output out[128];
 
     var ks_index = 0;
     var s[4][32], t[4][32];
     
-    var i,j,k,l;
+    var i,j,k,l,m;
     
-    component num2bits_1[4][2];
     component xor_1[4][32];
 
     for(i=0; i<4; i++)
     {
-        num2bits_1[i][0] = Num2Bits(32);
-        num2bits_1[i][0].in <== in[i];
-
-        num2bits_1[i][1] = Num2Bits(32);
-        num2bits_1[i][1].in <== ks[i+ks_index];
-
         for(j=0; j<32; j++)
         {
             xor_1[i][j] = XOR();
-            xor_1[i][j].a <== num2bits_1[i][0].out[j];
-            xor_1[i][j].b <== num2bits_1[i][1].out[j];
+            xor_1[i][j].a <== in[i*32+j];
+            xor_1[i][j].b <== ks[(i+ks_index)*32+j];
 
             s[i][j] = xor_1[i][j].out;
         }
@@ -41,9 +34,8 @@ template AES256Encrypt()
 
     component xor_2[13][4][3][32];
     component bits2num_1[13][4][4];
-    component num2bits_2[13][4][4];
+    component num2bits_1[13][4][4];
     component xor_3[13][4][32];
-    component num2bits_3[13][4];
 
     for(i=0; i<13; i++)
     {
@@ -52,39 +44,48 @@ template AES256Encrypt()
             for(k=0; k<4; k++)
             {
                 bits2num_1[i][j][k] = Bits2Num(8);
-                num2bits_2[i][j][k] = Num2Bits(32);
+                num2bits_1[i][j][k] = Num2Bits(32);
                 var s_tmp[32] = s[(j+k)%4];
                 
-                for(l=0; l<8; l++) bits2num_1[i][j][k].in[l] <== s_tmp[k*8+l];
+                for(l=0; l<8; l++) bits2num_1[i][j][k].in[l] <== s_tmp[k*8+7-l];
 
-                num2bits_2[i][j][k].in <-- emulated_aesenc_enc_table(k, bits2num_1[i][j][k].out);
+                num2bits_1[i][j][k].in <-- emulated_aesenc_enc_table(k, bits2num_1[i][j][k].out);
 
                 if(k==0)
                 {
-                    for(l=0; l<32; l++)
+                    for(l=0; l<4; l++)
                     {
-                        xor_2[i][j][k][l] = XOR();
-                        xor_2[i][j][k][l].a <== num2bits_2[i][j][k].out[l];
+                        for(m=0; m<8; m++)
+                        {
+                            xor_2[i][j][k][l*8+m] = XOR();
+                            xor_2[i][j][k][l*8+m].a <== num2bits_1[i][j][k].out[l*8+7-m];
+                        }
                     }
                 }
                 else if(k<3)
                 {
-                    for(l=0; l<32; l++)
+                    for(l=0; l<4; l++)
                     {
-                        xor_2[i][j][k-1][l].b <== num2bits_2[i][j][k].out[l];
+                        for(m=0; m<8; m++)
+                        {
+                            xor_2[i][j][k-1][l*8+m].b <== num2bits_1[i][j][k].out[l*8+7-m];
 
-                        xor_2[i][j][k][l] = XOR();
-                        xor_2[i][j][k][l].a <== xor_2[i][j][k-1][l].out;
+                            xor_2[i][j][k][l*8+m] = XOR();
+                            xor_2[i][j][k][l*8+m].a <== xor_2[i][j][k-1][l*8+m].out;
+                        }
                     }
                 }
                 else
                 {
-                    for(l=0; l<32; l++)
+                    for(l=0; l<4; l++)
                     {
-                        xor_2[i][j][k-1][l].b <== num2bits_2[i][j][k].out[l];
+                        for(m=0; m<8; m++)
+                        {
+                            xor_2[i][j][k-1][l*8+m].b <== num2bits_1[i][j][k].out[l*8+7-m];
 
-                        xor_3[i][j][l] = XOR();
-                        xor_3[i][j][l].a <== xor_2[i][j][k-1][l].out;
+                            xor_3[i][j][l*8+m] = XOR();
+                            xor_3[i][j][l*8+m].a <== xor_2[i][j][k-1][l*8+m].out;
+                        }
                     }
                 }
             }
@@ -92,12 +93,9 @@ template AES256Encrypt()
 
         for(j=0; j<4; j++)
         {
-            num2bits_3[i][j] = Num2Bits(32);
-            num2bits_3[i][j].in <== ks[j+ks_index];
-
             for(l=0; l<32; l++)
             {
-                xor_3[i][j][l].b <== num2bits_3[i][j].out[l];
+                xor_3[i][j][l].b <== ks[(j+ks_index)*32+l];
                 s[j][l] = xor_3[i][j][l].out;
             }
         }
@@ -112,7 +110,7 @@ template AES256Encrypt()
         for(j=0; j<4; j++)
         {
             bits2num_2[i*4+j] = Bits2Num(8);
-            for(k=0; k<8; k++) bits2num_2[i*4+j].in[k] <== s[i][j*8+k];
+            for(k=0; k<8; k++) bits2num_2[i*4+j].in[k] <== s[i][j*8+7-k];
             s_bytes[i*4+j] = bits2num_2[i*4+j].out;
         }
     }
@@ -122,41 +120,35 @@ template AES256Encrypt()
     for(i=0; i<16; i++) row_shifting.in[i] <== s_bytes[i];
     for(i=0; i<16; i++) sub_bytes.in[i] <== row_shifting.out[i];
 
-    component num2bits_5[16];
+    component num2bits_2[16];
 
     for(i=0; i<4; i++)
     {
         for(j=0; j<4; j++)
         {
-            num2bits_5[i*4+j] = Num2Bits(8);
-            num2bits_5[i*4+j].in <== sub_bytes.out[i*4+j];
-            for(k=0; k<8; k++) s[i][j*8+k] = num2bits_5[i*4+j].out[k];
+            num2bits_2[i*4+j] = Num2Bits(8);
+            num2bits_2[i*4+j].in <== sub_bytes.out[i*4+j];
+            for(k=0; k<8; k++) s[i][j*8+k] = num2bits_2[i*4+j].out[7-k];
         }
     }
 
-    component num2bits_6[4];
     component xor_4[4][32];
 
     for(i=0; i<4; i++)
     {
-        num2bits_6[i] = Num2Bits(32);
-        num2bits_6[i].in <== ks[i+ks_index];
         for(j=0; j<32; j++)
         {
             xor_4[i][j] = XOR();
             xor_4[i][j].a <== s[i][j];
-            xor_4[i][j].b <== num2bits_6[i].out[j];
+            xor_4[i][j].b <== ks[(i+ks_index)*32+j];
 
             s[i][j] = xor_4[i][j].out;
         }
     }
 
-    component bits2num_3[4];
     for(i=0; i<4; i++)
     {
-        bits2num_3[i] = Bits2Num(32);
-        for(j=0; j<32; j++) bits2num_3[i].in[j] <== s[i][j];
-        out[i] <== bits2num_3[i].out;
+        for(j=0; j<32; j++) out[i*32+j] <== s[i][j];
     }
 }
 

--- a/circuits/gcm_siv_dec_2_keys.circom
+++ b/circuits/gcm_siv_dec_2_keys.circom
@@ -8,228 +8,189 @@ include "polyval.circom";
 include "helper_functions.circom";
 include "../node_modules/circomlib/circuits/mux1.circom";
 
-template GCM_SIV_DEC_2_Keys(aad_len, msg_len)
+template GCM_SIV_DEC_2_Keys(n_bits_aad, n_bits_msg)
 {
-    signal input K1[32];
-    signal input N[16];
-    signal input AAD[aad_len];
-    signal input CIPHERTEXT[msg_len+16];
+    var aad_len = n_bits_aad/8;
+    var msg_len = n_bits_msg/8;
+    assert(aad_len%16 == 0);
+    assert(msg_len%16 == 0);
+    signal input K1[256];
+    signal input N[128];
+    signal input AAD[n_bits_aad];
+    signal input CT[(msg_len+16)*8];
 
-    signal output MSG[msg_len];
+    signal output MSG[n_bits_msg];
     signal output success;
 
     var i, j, k;
 
-    var MSG_t[msg_len];
-    var CT[msg_len];
-    for(i=0; i<msg_len; i++) CT[i] = CIPHERTEXT[i];
-    var TAG[16];
-    for(i=0; i<16; i++) TAG[i] = CIPHERTEXT[msg_len+i];
-    var ks[60];
-    var _N[4];
-    var _T[12];
-    var Record_Hash_Key[2];
-    var Record_Enc_Key_64[4];
-    var T[2] = [0, 0];
-    var new_TAG[2];
-    var CTR[2];
-    var LENBLK[2];
+    var MSG_t[msg_len*8];
+    var CT_msg[msg_len*8];
+    for(i=0; i<msg_len*8; i++) CT_msg[i] = CT[i];
+    var TAG[128];
+    for(i=0; i<128; i++) TAG[i] = CT[msg_len*8+i];
+    var ks[1920];
+    var _N[128];
+    var _T[768];
+    var Record_Hash_Key[128];
+    var Record_Enc_Key[256];
+    var T[2][64];
+    for(i=0; i<2; i++)
+    {
+        for(j=0; j<64; j++) T[i][j] = 0;
+    }
+    var new_TAG[128];
+    var CTR[128];
+    var LENBLK_bits[2][64];
 
-    LENBLK[0] = aad_len*8;
-    LENBLK[1] = msg_len*8;
+    component num2bits_1[2];
+    num2bits_1[0] = Num2Bits(64);
+    num2bits_1[0].in <== aad_len*8;
+    num2bits_1[1] = Num2Bits(64);
+    num2bits_1[1].in <== msg_len*8;
 
-    var TAG_64_1[2];
-    component typecast_1 = Typecast(16, 8, 64);
-    for(i=0; i<16; i++) typecast_1.in[i] <== TAG[i];
-    TAG_64_1 = typecast_1.out;
+    for(i=0; i<2; i++)
+    {
+        for(j=0; j<8; j++)
+        {
+            for(k=0; k<8; k++) LENBLK_bits[i][j*8+k] = num2bits_1[i].out[j*8+7-k];
+        }
+    }
 
-    CTR[0] = TAG_64_1[0];
-    CTR[1] = TAG_64_1[1];
-
-    var CTR_8[16];
-    component typecast_2 = Typecast(2, 64, 8);
-    for(i=0; i<2; i++) typecast_2.in[i] <== CTR[i];
-    CTR_8 = typecast_2.out;
-
-    component int_or_1 = IntOr(8);
-    int_or_1.a <== CTR_8[15];
-    int_or_1.b <== 128;
-    CTR_8[15] = int_or_1.out;
+    for(i=0; i<128; i++) CTR[i] = TAG[i];
+    CTR[15*8] = 1;
 
     component key_expansion_1 = AES256KeyExpansion();
-    for(i=0; i<32; i++) key_expansion_1.key[i] <== K1[i];
+    for(i=0; i<256; i++) key_expansion_1.key[i] <== K1[i];
     ks = key_expansion_1.w;
 
-    var N_32[4];
-    component typecast_3 = Typecast(16, 8, 32);
-    for(i=0; i<16; i++) typecast_3.in[i] <== N[i];
-    N_32 = typecast_3.out;
-    _N[1] = N_32[0];
-    _N[2] = N_32[1];
-    _N[3] = N_32[2];
-
-    component aes_256_encrypt_1[6];
-    component typecast_4[6];
-    for(i=0; i<6; i++)
+    for(i=0; i<3*32; i++)
     {
-        aes_256_encrypt_1[i] = AES256Encrypt();
-        typecast_4[i] = Typecast(4, 32, 64);
+        _N[i+32] = N[i];
     }
+
+    component num2bits_2[6];
+    component aes_256_encrypt_1[6];
 
     for(i=0; i<6; i++) 
     {
-        _N[0] = i;
-        var _T_32[4];
+        aes_256_encrypt_1[i] = AES256Encrypt();
+        num2bits_2[i] = Num2Bits(32);
+        num2bits_2[i].in <== i;
+        for(j=0; j<4; j++)
+        {
+            for(k=0; k<8; k++) _N[j*8+k] = num2bits_2[i].out[j*8+7-k];
+        }
+        var _T_tmp[128];
 
-        for(j=0; j<4; j++) aes_256_encrypt_1[i].in[j] <== _N[j];
-        for(j=0; j<60; j++) aes_256_encrypt_1[i].ks[j] <== ks[j];
-        _T_32 = aes_256_encrypt_1[i].out;
-
-        for(j=0; j<4; j++) typecast_4[i].in[j] <== _T_32[j];
-        _T[2*i] = typecast_4[i].out[0];
-        _T[2*i+1] = typecast_4[i].out[1];
+        for(j=0; j<128; j++) aes_256_encrypt_1[i].in[j] <== _N[j];
+        for(j=0; j<1920; j++) aes_256_encrypt_1[i].ks[j] <== ks[j];
+        _T_tmp = aes_256_encrypt_1[i].out;
+        for(j=0; j<128; j++) _T[i*128+j] = _T_tmp[j];
     }
 
-    Record_Hash_Key[0] = _T[0];
-    Record_Hash_Key[1] = _T[2];
-    Record_Enc_Key_64[0] = _T[4];
-    Record_Enc_Key_64[1] = _T[6];
-    Record_Enc_Key_64[2] = _T[8];
-    Record_Enc_Key_64[3] = _T[10];
-
-    var Record_Enc_Key[32];
-    component typecast_5 = Typecast(4, 64, 8);
-    for(i=0; i<4; i++) typecast_5.in[i] <== Record_Enc_Key_64[i];
-    Record_Enc_Key = typecast_5.out;
+    for(i=0; i<64; i++) Record_Hash_Key[i] = _T[i];
+    for(i=0; i<64; i++) Record_Hash_Key[i+64] = _T[64*2+i];
+    for(i=0; i<64; i++) Record_Enc_Key[i] = _T[64*4+i];
+    for(i=0; i<64; i++) Record_Enc_Key[i+64] = _T[64*6+i];
+    for(i=0; i<64; i++) Record_Enc_Key[i+64*2] = _T[64*8+i];
+    for(i=0; i<64; i++) Record_Enc_Key[i+64*3] = _T[64*10+i];
 
     component key_expansion_2 = AES256KeyExpansion();
-    for(i=0; i<32; i++) key_expansion_2.key[i] <== Record_Enc_Key[i];
+    for(i=0; i<256; i++) key_expansion_2.key[i] <== Record_Enc_Key[i];
     ks = key_expansion_2.w;
 
-    var CTR_32[4];
-    component typecast_6 = Typecast(16, 8, 32);
-    for(i=0; i<16; i++) typecast_6.in[i] <== CTR_8[i];
-    CTR_32 = typecast_6.out;
-
-    component aes_256_ctr = AES256CTR(msg_len);
-    for(i=0; i<msg_len; i++) aes_256_ctr.in[i] <== CT[i];
-    for(i=0; i<4; i++) aes_256_ctr.ctr[i] <== CTR_32[i];
-    for(i=0; i<60; i++) aes_256_ctr.ks[i] <== ks[i];
+    component aes_256_ctr = AES256CTR(msg_len*8);
+    for(i=0; i<msg_len*8; i++) aes_256_ctr.in[i] <== CT_msg[i];
+    for(i=0; i<128; i++) aes_256_ctr.ctr[i] <== CTR[i];
+    for(i=0; i<1920; i++) aes_256_ctr.ks[i] <== ks[i];
     MSG_t = aes_256_ctr.out;
 
-    component typecast_7 = Typecast(aad_len, 8, 64);
-    component polyval_1 = POLYVAL(aad_len);
+    component polyval_1 = POLYVAL(n_bits_aad);
     if(aad_len != 0)
     {
-        var AAD_64[aad_len/8];
-        
-        for(i=0; i<aad_len; i++) typecast_7.in[i] <== AAD[i];
-        AAD_64 = typecast_7.out;
-
-        
-        for(i=0; i<aad_len/8; i++) polyval_1.in[i] <== AAD_64[i];
+        for(i=0; i<n_bits_aad; i++) polyval_1.in[i] <== AAD[i];
+        for(i=0; i<128; i++) polyval_1.H[i] <== Record_Hash_Key[i];
         for(i=0; i<2; i++)
         {
-            polyval_1.H[i] <== Record_Hash_Key[i];
-            polyval_1.T[i] <== T[i];
+            for(j=0; j<64; j++) polyval_1.T[i][j] <== T[i][j];
         }
-
         T = polyval_1.result;
     }
 
-    var MSG_64[msg_len/8];
-    component typecast_8 = Typecast(msg_len, 8, 64);
-    for(i=0; i<msg_len; i++) typecast_8.in[i] <== MSG_t[i];
-    MSG_64 = typecast_8.out;
-
-    component polyval_2 = POLYVAL(msg_len);
-    for(i=0; i<msg_len/8; i++) polyval_2.in[i] <== MSG_64[i];
+    component polyval_2 = POLYVAL(n_bits_msg);
+    for(i=0; i<n_bits_msg; i++) polyval_2.in[i] <== MSG_t[i];
+    for(i=0; i<128; i++) polyval_2.H[i] <== Record_Hash_Key[i];
     for(i=0; i<2; i++)
     {
-        polyval_2.H[i] <== Record_Hash_Key[i];
-        polyval_2.T[i] <== T[i];
+        for(j=0; j<64; j++) polyval_2.T[i][j] <== T[i][j];
     }
-
     T = polyval_2.result;
 
-    component polyval_3 = POLYVAL(16);
-    for(i=0; i<2; i++) polyval_3.in[i] <== LENBLK[i];
+    component polyval_3 = POLYVAL(128);
     for(i=0; i<2; i++)
     {
-        polyval_3.H[i] <== Record_Hash_Key[i];
-        polyval_3.T[i] <== T[i];
+        for(j=0; j<64; j++) polyval_3.in[i*64+j] <== LENBLK_bits[i][j];
     }
-
+    for(i=0; i<128; i++) polyval_3.H[i] <== Record_Hash_Key[i];
+    for(i=0; i<2; i++)
+    {
+        for(j=0; j<64; j++) polyval_3.T[i][j] <== T[i][j];
+    }
     T = polyval_3.result;
 
-    var N_64[2];
-    component typecast_9 = Typecast(16, 8, 64);
-    for(i=0; i<16; i++) typecast_9.in[i] <== N[i];
-    N_64 = typecast_9.out;
-
-    component int_xor_1[2];
-    for(i=0; i<2; i++) int_xor_1[i] = IntXor(64);
+    component xor_1[2][64];
 
     for(i=0; i<2; i++)
     {
-        int_xor_1[i].a <== T[i];
-        int_xor_1[i].b <== N_64[i];
+        for(j=0; j<64; j++)
+        {
+            xor_1[i][j] = XOR();
+            xor_1[i][j].a <== T[i][j];
+            xor_1[i][j].b <== N[i*64+j];
 
-        T[i] = int_xor_1[i].out;
+            T[i][j] = xor_1[i][j].out;
+        }
     }
 
-    new_TAG[0] = T[0];
-    new_TAG[1] = T[1];
-
-    var new_TAG_8[16];
-    component typecast_10 = Typecast(2, 64, 8);
-    for(i=0; i<2; i++) typecast_10.in[i] <== new_TAG[i];
-    new_TAG_8 = typecast_10.out;
-
-    component int_and_1 = IntAnd(8);
-    int_and_1.a <== new_TAG_8[15];
-    int_and_1.b <== 127;
-    new_TAG_8[15] = int_and_1.out;
-
-    var new_TAG_32[4];
-    component typecast_11 = Typecast(16, 8, 32);
-    for(i=0; i<16; i++) typecast_11.in[i] <== new_TAG_8[i];
-    new_TAG_32 = typecast_11.out;
-
-    component aes_256_encrypt_2 = AES256Encrypt();
-    for(i=0; i<4; i++) aes_256_encrypt_2.in[i] <== new_TAG_32[i];
-    for(i=0; i<60; i++) aes_256_encrypt_2.ks[i] <== ks[i];
-    new_TAG_32 = aes_256_encrypt_2.out;
-
-    var new_TAG_64[2];
-    component typecast_12 = Typecast(4, 32, 64);
-    for(i=0; i<4; i++) typecast_12.in[i] <== new_TAG_32[i];
-    new_TAG_64 = typecast_12.out;
-
-    component is_equal_1[2];
-    for(i=0; i<2; i++) is_equal_1[i] = IsEqual();
-
     for(i=0; i<2; i++)
     {
-        is_equal_1[i].in[0] <== new_TAG_64[i];
-        is_equal_1[i].in[1] <== TAG_64_1[i];
+        for(j=0; j<64; j++) new_TAG[i*64+j] = T[i][j];
+    }
+
+    new_TAG[15*8] = 0;
+
+    component aes_256_encrypt_2 = AES256Encrypt();
+    for(i=0; i<128; i++) aes_256_encrypt_2.in[i] <== new_TAG[i];
+    for(i=0; i<1920; i++) aes_256_encrypt_2.ks[i] <== ks[i];
+    new_TAG = aes_256_encrypt_2.out;
+
+    component is_equal_1[128];
+    for(i=0; i<128; i++) is_equal_1[i] = IsEqual();
+
+    for(i=0; i<128; i++)
+    {
+        is_equal_1[i].in[0] <== new_TAG[i];
+        is_equal_1[i].in[1] <== TAG[i];
     }
 
     component mux_1 = Mux1();
     mux_1.c[0] <== 0;
     mux_1.c[1] <== 1;
-    mux_1.s <== is_equal_1[0].out * is_equal_1[1].out;
+    component multi_and = MultiAND(128);
+    for(i=0; i<128; i++) multi_and.in[i] <== is_equal_1[i].out;
+    mux_1.s <== multi_and.out;
 
     success <== mux_1.out;
 
-    component mux_2[msg_len];
-    for(i=0; i<msg_len; i++) mux_2[i] = Mux1();
+    component mux_2[msg_len*8];
+    for(i=0; i<msg_len*8; i++) mux_2[i] = Mux1();
 
-    for(i=0; i<msg_len; i++)
+    for(i=0; i<msg_len*8; i++)
     {
-        mux_2[i].c[0] <== CT[i];
+        mux_2[i].c[0] <== CT_msg[i];
         mux_2[i].c[1] <== MSG_t[i];
-        mux_2[i].s <== is_equal_1[0].out * is_equal_1[1].out;
+        mux_2[i].s <== multi_and.out;
 
         MSG[i] <== mux_2[i].out;
     }

--- a/circuits/gfmul_int.circom
+++ b/circuits/gfmul_int.circom
@@ -6,14 +6,26 @@ include "helper_functions.circom";
 
 template GFMULInt()
 {
-    signal input a[2];
-    signal input b[2];
-    signal output res[2];
+    signal input a[2][64];
+    signal input b[2][64];
+    signal output res[2][64];
 
-    var tmp[5][2];
+    var tmp[5][2][64];
     var XMMMASK[2] = [0x1, 0xc200000000000000];
 
-    var i, j, k, l;
+        var i, j, k;
+
+    component num2bits_1[2];
+    var XMMMASK_bits[2][64];
+    for(i=0; i<2; i++)
+    {
+        num2bits_1[i] = Num2Bits(64);
+        num2bits_1[i].in <== XMMMASK[i];
+        for(j=0; j<8; j++)
+        {
+            for(k=0; k<8; k++) XMMMASK_bits[i][j*8+k] = num2bits_1[i].out[j*8+7-k];
+        }
+    }
 
     component vclmul_emulator_1[4];
     
@@ -22,208 +34,135 @@ template GFMULInt()
         vclmul_emulator_1[i] = VCLMULEmulator(i);
         for(j=0; j<2; j++)
         {
-            vclmul_emulator_1[i].src1[j] <== a[j];
-            vclmul_emulator_1[i].src2[j] <== b[j];
+            for(k=0; k<64; k++)
+            {
+                vclmul_emulator_1[i].src1[j][k] <== a[j][k];
+                vclmul_emulator_1[i].src2[j][k] <== b[j][k];
+            }
         }
 
         tmp[i+1] = vclmul_emulator_1[i].destination;
     }
 
-    component num2bits_1[4][2];
-    var tmp_bytes[5][4][32];
-    for(i=0; i<4; i++)
+    component xor_1[2][64];
+    for(i=0; i<2; i++)
     {
-        for(j=0; j<2; j++)
-        {
-            num2bits_1[i][j] = Num2Bits(64);
-            num2bits_1[i][j].in <== tmp[i+1][j];
-
-            for(k=0; k<2; k++)
-            {
-                for(l=0; l<32; l++) tmp_bytes[i+1][j*2+k][l] = num2bits_1[i][j].out[k*32+l];
-            }
-        }
-    }
-
-    component xor_1[4][32];
-    for(i=0; i<4; i++)
-    {
-        for(j=0; j<32; j++)
+        for(j=0; j<64; j++)
         {
             xor_1[i][j] = XOR();
-            xor_1[i][j].a <== tmp_bytes[2][i][j];
-            xor_1[i][j].b <== tmp_bytes[3][i][j];
+            xor_1[i][j].a <== tmp[2][i][j];
+            xor_1[i][j].b <== tmp[3][i][j];
 
-            tmp_bytes[2][i][j] = xor_1[i][j].out;
+            tmp[2][i][j] = xor_1[i][j].out;
         }
     }
 
+    for(i=0; i<64; i++) tmp[3][0][i] = 0;
+
+    for(i=0; i<64; i++) tmp[3][1][i] = tmp[2][0][i];
+
+    for(i=0; i<64; i++) tmp[2][0][i] = tmp[2][1][i];
+
+    for(i=0; i<64; i++) tmp[2][1][i] = 0;
+
+    component xor_2[2][64];
     for(i=0; i<2; i++)
     {
-        for(j=0; j<32; j++) tmp_bytes[3][i][j] = 0;
-    }
-
-    for(i=2; i<4; i++)
-    {
-        for(j=0; j<32; j++) tmp_bytes[3][i][j] = tmp_bytes[2][i-2][j];
-    }
-
-    for(i=0; i<2; i++)
-    {
-        for(j=0; j<32; j++) tmp_bytes[2][i][j] = tmp_bytes[2][i+2][j];
-    }
-
-    for(i=2; i<4; i++)
-    {
-        for(j=0; j<32; j++) tmp_bytes[2][i][j] = 0;
-    }
-
-    component xor_2[4][32];
-    for(i=0; i<4; i++)
-    {
-        for(j=0; j<32; j++)
+        for(j=0; j<64; j++)
         {
             xor_2[i][j] = XOR();
-            xor_2[i][j].a <== tmp_bytes[1][i][j];
-            xor_2[i][j].b <== tmp_bytes[3][i][j];
+            xor_2[i][j].a <== tmp[1][i][j];
+            xor_2[i][j].b <== tmp[3][i][j];
 
-            tmp_bytes[1][i][j] = xor_2[i][j].out;
+            tmp[1][i][j] = xor_2[i][j].out;
         }
     }
 
-    component xor_3[4][32];
-    for(i=0; i<4; i++)
-    {
-        for(j=0; j<32; j++)
-        {
-            xor_3[i][j] = XOR();
-            xor_3[i][j].a <== tmp_bytes[4][i][j];
-            xor_3[i][j].b <== tmp_bytes[2][i][j];
-
-            tmp_bytes[4][i][j] = xor_3[i][j].out;
-        }
-    }
-
-    component bits2num_1[2];
+    component xor_3[2][64];
     for(i=0; i<2; i++)
     {
-        bits2num_1[i] = Bits2Num(64);
-        for(j=0; j<2; j++)
+        for(j=0; j<64; j++)
         {
-            for(k=0; k<32; k++)
-            {
-                bits2num_1[i].in[j*32+k] <== tmp_bytes[1][i*2+j][k];
-            }
+            xor_3[i][j] = XOR();
+            xor_3[i][j].a <== tmp[4][i][j];
+            xor_3[i][j].b <== tmp[2][i][j];
+
+            tmp[4][i][j] = xor_3[i][j].out;
         }
-        tmp[1][i] = bits2num_1[i].out;
     }
 
     component vclmul_emulator_2 = VCLMULEmulator(1);
     for(i=0; i<2; i++)
     {
-        vclmul_emulator_2.src1[i] <== XMMMASK[i];
-        vclmul_emulator_2.src2[i] <== tmp[1][i];
+        for(j=0; j<64; j++)
+        {
+            vclmul_emulator_2.src1[i][j] <== XMMMASK_bits[i][j];
+            vclmul_emulator_2.src2[i][j] <== tmp[1][i][j];
+        }
     }
 
     tmp[2] = vclmul_emulator_2.destination;
 
-    component num2bits_2[2];
-    for(i=0; i<2; i++)
+    for(i=0; i<64; i++)
     {
-        num2bits_2[i] = Num2Bits(64);
-        num2bits_2[i].in <== tmp[2][i];
-        for(j=0; j<2; j++)
-        {
-            for(k=0; k<32; k++) tmp_bytes[2][i*2+j][k] = num2bits_2[i].out[j*32+k];
-        }
+        tmp[3][0][i] = tmp[1][1][i];
+        tmp[3][1][i] = tmp[1][0][i];
     }
 
-    tmp_bytes[3][0] = tmp_bytes[1][2];
-    tmp_bytes[3][1] = tmp_bytes[1][3];
-    tmp_bytes[3][2] = tmp_bytes[1][0];
-    tmp_bytes[3][3] = tmp_bytes[1][1];
-
-    component xor_4[4][32];
-    for(i=0; i<4; i++)
+    component xor_4[2][64];
+    for(i=0; i<2; i++)
     {
-        for(j=0; j<32; j++)
+        for(j=0; j<64; j++)
         {
             xor_4[i][j] = XOR();
-            xor_4[i][j].a <== tmp_bytes[2][i][j];
-            xor_4[i][j].b <== tmp_bytes[3][i][j];
+            xor_4[i][j].a <== tmp[2][i][j];
+            xor_4[i][j].b <== tmp[3][i][j];
 
-            tmp_bytes[1][i][j] = xor_4[i][j].out;
+            tmp[1][i][j] = xor_4[i][j].out;
         }
-    }
-
-    component bits2num_2[2];
-    for(i=0; i<2; i++)
-    {
-        bits2num_2[i] = Bits2Num(64);
-        for(j=0; j<2; j++)
-        {
-            for(k=0; k<32; k++)
-            {
-                bits2num_2[i].in[j*32+k] <== tmp_bytes[1][i*2+j][k];
-            }
-        }
-        tmp[1][i] = bits2num_2[i].out;
     }
 
     component vclmul_emulator_3 = VCLMULEmulator(1);
     for(i=0; i<2; i++)
     {
-        vclmul_emulator_3.src1[i] <== XMMMASK[i];
-        vclmul_emulator_3.src2[i] <== tmp[1][i];
+        for(j=0; j<64; j++)
+        {
+            vclmul_emulator_3.src1[i][j] <== XMMMASK_bits[i][j];
+            vclmul_emulator_3.src2[i][j] <== tmp[1][i][j];
+        }
     }
 
     tmp[2] = vclmul_emulator_3.destination;
 
-    component num2bits_3[2];
-    for(i=0; i<2; i++)
+    for(i=0; i<64; i++)
     {
-        num2bits_3[i] = Num2Bits(64);
-        num2bits_3[i].in <== tmp[2][i];
-        for(j=0; j<2; j++)
-        {
-            for(k=0; k<32; k++) tmp_bytes[2][i*2+j][k] = num2bits_3[i].out[j*32+k];
-        }
+        tmp[3][0][i] = tmp[1][1][i];
+        tmp[3][1][i] = tmp[1][0][i];
     }
 
-    tmp_bytes[3][0] = tmp_bytes[1][2];
-    tmp_bytes[3][1] = tmp_bytes[1][3];
-    tmp_bytes[3][2] = tmp_bytes[1][0];
-    tmp_bytes[3][3] = tmp_bytes[1][1];
-
-    component xor_5[4][32];
-    for(i=0; i<4; i++)
+    component xor_5[2][64];
+    for(i=0; i<2; i++)
     {
-        for(j=0; j<32; j++)
+        for(j=0; j<64; j++)
         {
             xor_5[i][j] = XOR();
-            xor_5[i][j].a <== tmp_bytes[2][i][j];
-            xor_5[i][j].b <== tmp_bytes[3][i][j];
+            xor_5[i][j].a <== tmp[2][i][j];
+            xor_5[i][j].b <== tmp[3][i][j];
 
-            tmp_bytes[1][i][j] = xor_5[i][j].out;
+            tmp[1][i][j] = xor_5[i][j].out;
         }
     }
 
-    component xor_6[4][32];
-    component bits2num_3[2];
+    component xor_6[2][64];
     for(i=0; i<2; i++)
     {
-        bits2num_3[i] = Bits2Num(64);
-        for(j=0; j<2; j++)
+        for(j=0; j<64; j++)
         {
-            for(k=0; k<32; k++)
-            {
-                xor_6[i*2+j][k] = XOR();
-                xor_6[i*2+j][k].a <== tmp_bytes[1][i*2+j][k];
-                xor_6[i*2+j][k].b <== tmp_bytes[4][i*2+j][k];
+            xor_6[i][j] = XOR();
+            xor_6[i][j].a <== tmp[1][i][j];
+            xor_6[i][j].b <== tmp[4][i][j];
 
-                bits2num_3[i].in[j*32+k] <== xor_6[i*2+j][k].out;
-            }
+            res[i][j] <== xor_6[i][j].out;
         }
-        res[i] <== bits2num_3[i].out;
     }
 }

--- a/circuits/mul.circom
+++ b/circuits/mul.circom
@@ -5,23 +5,23 @@ include "helper_functions.circom";
 
 template Mul()
 {
-    signal input src1;
-    signal input src2;
-    signal output out[2];
+    signal input src1[64];
+    signal input src2[64];
+    signal output out[128];
 
-    var i, j;
+    var i, j, k;
 
     var dst_bytes[2][64];
     var src1_bytes[64], src2_bytes[64];
 
-    component num2bits_1 = Num2Bits(64);
-    component num2bits_2 = Num2Bits(64);
-
-    num2bits_1.in <== src1;
-    num2bits_2.in <== src2;
-
-    src1_bytes = num2bits_1.out;
-    src2_bytes = num2bits_2.out;
+    for(i=0; i<8; i++)
+    {
+        for(j=0; j<8; j++)
+        {
+            src1_bytes[i*8+j] = src1[i*8+7-j];
+            src2_bytes[i*8+j] = src2[i*8+7-j];
+        }
+    }
 
     component xor_1[64][2][64];
 
@@ -71,15 +71,12 @@ template Mul()
         dst_bytes[1][63] = 0;
     }
 
-    component bits2num_1[2];
     for(i=0; i<2; i++)
     {
-        bits2num_1[i] = Bits2Num(64);
-        for(j=0; j<64; j++)
+        for(j=0; j<8; j++)
         {
-            bits2num_1[i].in[j] <== dst_bytes[i][j];
+            for(k=0; k<8; k++) out[i*64+j*8+k] <== dst_bytes[i][j*8+7-k];
         }
-        out[i] <== bits2num_1[i].out;
     }
 
 }

--- a/circuits/polyval.circom
+++ b/circuits/polyval.circom
@@ -4,51 +4,60 @@ pragma circom 2.0.0;
 include "gfmul_int.circom";
 include "helper_functions.circom";
 
-template POLYVAL(msg_len)
+template POLYVAL(n_bits)
 {
-    signal input in[msg_len/8];
-    signal input H[2];
-    signal input T[2];
-    signal output result[2];
+    var msg_len = n_bits/8;
+    signal input in[n_bits];
+    signal input H[128];
+    signal input T[2][64];
+    signal output result[2][64];
 
-    var current_res[2] = T, in_t[2];
+    var current_res[2][64] = T, in_t[2][64];
 
     var i, j, k;
     var blocks = msg_len/16;
 
-    component int_xor_1[blocks][2];
+    component xor_1[blocks][2][64];
     component gfmul_int_1[blocks];
-    for(i=0; i<blocks; i++)
-    {
-        for(j=0; j<2; j++) int_xor_1[i][j] = IntXor(64);
-        gfmul_int_1[i] = GFMULInt();
-    }
     
     if(blocks != 0)
     {
         for(i=0; i<blocks; i++)
         {
-            in_t[0] = in[2*i];
-            in_t[1] = in[2*i+1];
-
-            for(j=0; j<2; j++)
+            for(j=0; j<64; j++)
             {
-                int_xor_1[i][j].a <== current_res[j];
-                int_xor_1[i][j].b <== in_t[j];
-
-                current_res[j] = int_xor_1[i][j].out;
+                in_t[0][j] = in[2*i*64+j];
+                in_t[1][j] = in[(2*i+1)*64+j];
             }
 
             for(j=0; j<2; j++)
             {
-                gfmul_int_1[i].a[j] <== current_res[j];
-                gfmul_int_1[i].b[j] <== H[j];
+                for(k=0; k<64; k++)
+                {
+                    xor_1[i][j][k] = XOR();
+                    xor_1[i][j][k].a <== current_res[j][k];
+                    xor_1[i][j][k].b <== in_t[j][k];
+
+                    current_res[j][k] = xor_1[i][j][k].out;
+                }
+            }
+
+            gfmul_int_1[i] = GFMULInt();
+            for(j=0; j<2; j++)
+            {
+                for(k=0; k<64; k++)
+                {
+                    gfmul_int_1[i].a[j][k] <== current_res[j][k];
+                    gfmul_int_1[i].b[j][k] <== H[j*64+k];
+                }
             }
 
             current_res = gfmul_int_1[i].res;
         }
     }
 
-    result[0] <== current_res[0];
-    result[1] <== current_res[1];
+    for(i=0; i<2; i++)
+    {
+        for(j=0; j<64; j++) result[i][j] <== current_res[i][j];
+    }
 }

--- a/circuits/vclmul_emulator.circom
+++ b/circuits/vclmul_emulator.circom
@@ -4,34 +4,45 @@ pragma circom 2.0.0;
 include "mul.circom";
 
 template VCLMULEmulator(imm) {
-    signal input src1[2];
-    signal input src2[2];
-    signal output destination[2];
+    signal input src1[2][64];
+    signal input src2[2][64];
+    signal output destination[2][64];
 
     component mul = Mul();
 
+    var i, j;
+
     if(imm == 0){
-        mul.src1 <== src1[0];
-        mul.src2 <== src2[0];
-        destination[0] <== mul.out[0];
-        destination[1] <== mul.out[1];
+        for(i=0; i<64; i++)
+        {
+            mul.src1[i] <== src1[0][i];
+            mul.src2[i] <== src2[0][i];
+        }
     }
     else if(imm == 1){
-        mul.src1 <== src1[1];
-        mul.src2 <== src2[0];
-        destination[0] <== mul.out[0];
-        destination[1] <== mul.out[1];
+        for(i=0; i<64; i++)
+        {
+            mul.src1[i] <== src1[1][i];
+            mul.src2[i] <== src2[0][i];
+        }
     }
     else if(imm == 2){
-        mul.src1 <== src1[0];
-        mul.src2 <== src2[1];
-        destination[0] <== mul.out[0];
-        destination[1] <== mul.out[1];
+        for(i=0; i<64; i++)
+        {
+            mul.src1[i] <== src1[0][i];
+            mul.src2[i] <== src2[1][i];
+        }
     }
     else if(imm == 3){
-        mul.src1 <== src1[1];
-        mul.src2 <== src2[1];
-        destination[0] <== mul.out[0];
-        destination[1] <== mul.out[1];
+        for(i=0; i<64; i++)
+        {
+            mul.src1[i] <== src1[1][i];
+            mul.src2[i] <== src2[1][i];
+        }
+    }
+
+    for(i=0; i<2; i++)
+    {
+        for(j=0; j<64; j++) destination[i][j] <== mul.out[i*64+j];
     }
 }

--- a/test/aes_256_ctr.test.js
+++ b/test/aes_256_ctr.test.js
@@ -2,7 +2,7 @@ const path = require("path");
 const assert = require("assert");
 const wasmTester = require("circom_tester").wasm;
 const Module = require("./module.js");
-
+const utils = require("./utils");
 
 describe("AES256 CTR Test", () => {
     it("Show do ctr correctly", async() => {
@@ -30,11 +30,23 @@ describe("AES256 CTR Test", () => {
             out.push(Module.HEAPU8[out_ptr/Uint8Array.BYTES_PER_ELEMENT + i]);
         }
 
-        let witness = await cir.calculateWitness({"ks":ks, "in":inp, "ctr":ctr});
-        witness = witness.slice(1,257);
-        console.log("expected", out);
-        console.log("witness", witness);
+        var ks_buffer = [];
+        for(let i=0; i<ks.length; i++)
+        {
+            ks_buffer.push(...utils.intToLEBuffer(ks[i], 4));
+        }
+        var ks_bits = utils.buffer2bits(ks_buffer);
 		
-        assert.ok(out.every((v, i)=> v == witness[i]));
+        var ctr_buffer = [];
+        for(let i=0; i<ctr.length; i++)
+        {
+            ctr_buffer.push(...utils.intToLEBuffer(ctr[i], 4));
+        }
+        var ctr_bits = utils.buffer2bits(ctr_buffer);
+
+        let witness = await cir.calculateWitness({"ks":ks_bits, "in":utils.buffer2bits(inp), "ctr":ctr_bits});
+        witness = witness.slice(1,2049);
+		
+        assert.ok(utils.buffer2bits(out).every((v, i)=> v == witness[i]));
     });
 });

--- a/test/aes_256_encrypt.test.js
+++ b/test/aes_256_encrypt.test.js
@@ -2,7 +2,7 @@ const path = require("path");
 const assert = require("assert");
 const wasmTester = require("circom_tester").wasm;
 const Module = require("./module.js");
-
+const utils = require("./utils");
 
 describe("AES256 Encrypt Test", () => {
     it("Show do encrypt correctly", async() => {
@@ -27,11 +27,30 @@ describe("AES256 Encrypt Test", () => {
             out.push(Module.HEAPU32[out_ptr/Uint32Array.BYTES_PER_ELEMENT + i]);
         }
 
-        let witness = await cir.calculateWitness({"ks":ks, "in":inp});
-        witness = witness.slice(1,5);
-        console.log("expected", out);
-        console.log("witness", witness);
+        var ks_buffer = [];
+        for(let i=0; i<ks.length; i++)
+        {
+            ks_buffer.push(...utils.intToLEBuffer(ks[i], 4));
+        }
+        var ks_bits = utils.buffer2bits(ks_buffer);
+
+        var inp_buffer = [];
+        for(let i=0; i<inp.length; i++)
+        {
+            inp_buffer.push(...utils.intToLEBuffer(inp[i], 4));
+        }
+        var inp_bits = utils.buffer2bits(inp_buffer);
+
+        var out_buffer = [];
+        for(let i=0; i<out.length; i++)
+        {
+            out_buffer.push(...utils.intToLEBuffer(out[i], 4));
+        }
+        var out_bits = utils.buffer2bits(out_buffer);
+
+        let witness = await cir.calculateWitness({"ks":ks_bits, "in":inp_bits});
+        witness = witness.slice(1,129);
 		
-        assert.ok(out.every((v, i)=> v == witness[i]));
+        assert.ok(out_bits.every((v, i)=> v == witness[i]));
     });
 });

--- a/test/aes_256_key_expansion.test.js
+++ b/test/aes_256_key_expansion.test.js
@@ -2,7 +2,7 @@ const path = require("path");
 const assert = require("assert");
 const wasmTester = require("circom_tester").wasm;
 const Module = require("./module.js");
-
+const utils = require("./utils");
 
 describe("AES256 Key Expansion test", () => {
     it("Show do key expansion correctly", async() => {
@@ -24,10 +24,15 @@ describe("AES256 Key Expansion test", () => {
             ks.push(Module.HEAPU32[ks_ptr/Uint32Array.BYTES_PER_ELEMENT + i]);
         }
 
-        let witness = await cir.calculateWitness({key: ip});
-        witness = witness.slice(1,61);    
-        console.log("Expected", ks);
-        console.log("witness", witness);
-        assert.ok(ks.every((v, i)=> v == witness[i]));
+        var ks_buffer = [];
+        for(let i=0; i<ks_len; i++)
+        {
+            ks_buffer.push(...utils.intToLEBuffer(ks[i], 4));
+        }
+        var ks_bits = utils.buffer2bits(ks_buffer);
+        
+        let witness = await cir.calculateWitness({key: utils.buffer2bits(ip)});
+        witness = witness.slice(1,1921);
+        assert.ok(ks_bits.every((v, i)=> v == witness[i]));
     });
 });

--- a/test/circuits/aes_256_ctr_test.circom
+++ b/test/circuits/aes_256_ctr_test.circom
@@ -2,4 +2,4 @@ pragma circom 2.0.0;
 
 include "../../circuits/aes_256_ctr.circom";
 
-component main = AES256CTR(256);
+component main = AES256CTR(2048);

--- a/test/circuits/gcm_siv_dec_2_keys_test.circom
+++ b/test/circuits/gcm_siv_dec_2_keys_test.circom
@@ -2,4 +2,4 @@ pragma circom 2.0.0;
 
 include "../../circuits/gcm_siv_dec_2_keys.circom";
 
-component main = GCM_SIV_DEC_2_Keys(0, 16);
+component main = GCM_SIV_DEC_2_Keys(0, 128);

--- a/test/circuits/gcm_siv_enc_2_keys_test.circom
+++ b/test/circuits/gcm_siv_enc_2_keys_test.circom
@@ -2,4 +2,4 @@ pragma circom 2.0.0;
 
 include "../../circuits/gcm_siv_enc_2_keys.circom";
 
-component main = GCM_SIV_ENC_2_Keys(0, 16);
+component main = GCM_SIV_ENC_2_Keys(0, 128);

--- a/test/circuits/polyval_test.circom
+++ b/test/circuits/polyval_test.circom
@@ -2,4 +2,4 @@ pragma circom 2.0.0;
 
 include "../../circuits/polyval.circom";
 
-component main = POLYVAL(64);
+component main = POLYVAL(512);

--- a/test/gcm_siv_dec_2_keys.test.js
+++ b/test/gcm_siv_dec_2_keys.test.js
@@ -1,7 +1,8 @@
 const path = require("path");
 const assert = require("assert");
 const wasmTester = require("circom_tester").wasm;
-
+const Module = require("./module.js");
+const utils = require("./utils");
 
 describe("Complete Decryption test", () => {
     it("Show do decryption correctly", async() => {
@@ -9,14 +10,39 @@ describe("Complete Decryption test", () => {
         const K1 = [1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0];
         const N = [3,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0];
         const AAD = [];
-        const CIPHERTEXT = [133,160,27,99,2,91,161,155,127,211,221,252,3,59,62,118,201,234,198,250,112,9,66,112,46,144,134,35,131,198,195,102];
-        const MSG = [1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0];
-        let witness = await cir.calculateWitness({"K1": K1, "N":N, "AAD":AAD, "CIPHERTEXT":CIPHERTEXT});
-        let success = witness[17];
-        witness = witness.slice(1, 17);
-        console.log("Expected", MSG);
-        console.log("witness", witness);
+        const CT = [133,160,27,99,2,91,161,155,127,211,221,252,3,59,62,118,201,234,198,250,112,9,66,112,46,144,134,35,131,198,195,102];
+
+        const MSG_length = CT.length-16;
+        var MSG = [];
+
+        const K1_ptr = Module._malloc(K1.length * Uint8Array.BYTES_PER_ELEMENT);
+        const N_ptr = Module._malloc(N.length * Uint8Array.BYTES_PER_ELEMENT);
+        const AAD_ptr = Module._malloc(AAD.length * Uint8Array.BYTES_PER_ELEMENT);
+        const MSG_ptr = Module._malloc(MSG_length * Uint8Array.BYTES_PER_ELEMENT);
+        const CT_ptr = Module._malloc(MSG_length * Uint8Array.BYTES_PER_ELEMENT);
+        const TAG_ptr = Module._malloc(16 * Uint8Array.BYTES_PER_ELEMENT);
+
+        Module.HEAPU8.set(new Uint8Array(K1), K1_ptr/Uint8Array.BYTES_PER_ELEMENT);
+        Module.HEAPU8.set(new Uint8Array(N), N_ptr/Uint8Array.BYTES_PER_ELEMENT);
+        Module.HEAPU8.set(new Uint8Array(AAD), AAD_ptr/Uint8Array.BYTES_PER_ELEMENT);
+        Module.HEAPU8.set(new Uint8Array(CT.slice(0, MSG_length)), CT_ptr/Uint8Array.BYTES_PER_ELEMENT);
+        Module.HEAPU8.set(new Uint8Array(CT.slice(MSG_length, CT.length)), TAG_ptr/Uint8Array.BYTES_PER_ELEMENT);
+
+        Module._GCM_SIV_DEC_2_Keys(MSG_ptr, TAG_ptr, K1_ptr, N_ptr, AAD_ptr, CT_ptr, BigInt(AAD.length), BigInt(MSG_length));
+
+        for(let i=0; i<MSG_length; i++)
+        {
+            MSG.push(Module.HEAPU8[MSG_ptr/Uint8Array.BYTES_PER_ELEMENT + i]);
+        }
+
+        var K1_bits = utils.buffer2bits(K1);
+        var N_bits = utils.buffer2bits(N);
+        var AAD_bits = utils.buffer2bits(AAD);
+        var CT_bits = utils.buffer2bits(CT);
+        let witness = await cir.calculateWitness({"K1": K1_bits, "N": N_bits, "AAD": AAD_bits, "CT": CT_bits});
+        let success = witness[129];
+        witness = witness.slice(1, 129);
         assert.ok(success==1);
-        assert.ok(MSG.every((v, i)=> v == witness[i]));
+        assert.ok(utils.buffer2bits(MSG).every((v, i)=> v == witness[i]));
     });
 });

--- a/test/gcm_siv_enc_2_keys.test.js
+++ b/test/gcm_siv_enc_2_keys.test.js
@@ -1,8 +1,8 @@
 const path = require("path");
 const assert = require("assert");
-const crypto = require("crypto");
 const wasmTester = require("circom_tester").wasm;
 const Module = require("./module.js");
+const utils = require("./utils");
 
 describe("Complete Encryption test", () => {
     it("Show do encryption correctly", async() => {
@@ -37,18 +37,12 @@ describe("Complete Encryption test", () => {
             CT.push(Module.HEAPU8[TAG_ptr/Uint8Array.BYTES_PER_ELEMENT + i]);
         }
 
-        const CIPHERTEXT = Uint8Array.from(CT);
-
-        const hash = crypto.createHash("sha256")
-            .update(CIPHERTEXT)
-            .digest("hex");
-        const x1 = BigInt("0x"+hash.slice(0,32));
-        const x2 = BigInt("0x"+hash.slice(32));
-        const CT_sha256 = [x1, x2];
-        let witness = await cir.calculateWitness({"K1": K1, "N":N, "AAD":AAD, "MSG":MSG, "CIPHERTEXT_SHA256":CT_sha256});
-        witness = witness[1];
-        console.log("Expected", 1);
-        console.log("witness", witness);
-        assert.ok(witness==1);
+        var K1_bits = utils.buffer2bits(K1);
+        var N_bits = utils.buffer2bits(N);
+        var AAD_bits = utils.buffer2bits(AAD);
+        var MSG_bits = utils.buffer2bits(MSG);
+        let witness = await cir.calculateWitness({"K1": K1_bits, "N": N_bits, "AAD": AAD_bits, "MSG": MSG_bits});
+        witness = witness.slice(1, 257);
+        assert.ok(utils.buffer2bits(CT).every((v, i)=> v == witness[i]));
     });
 });

--- a/test/gfmul_int.test.js
+++ b/test/gfmul_int.test.js
@@ -2,7 +2,7 @@ const path = require("path");
 const assert = require("assert");
 const wasmTester = require("circom_tester").wasm;
 const Module = require("./module.js");
-
+const utils = require("./utils");
 
 describe("GFmul test", () => {
     it("Show do gf multiplication correctly", async() => {
@@ -27,10 +27,27 @@ describe("GFmul test", () => {
             res.push(BigInt(Module.HEAPU64[res_ptr/BigUint64Array.BYTES_PER_ELEMENT + i]));
         }
 
-        let witness = await cir.calculateWitness({"a": a, "b": b});
-        witness = witness.slice(1, 3);
-        console.log("Expected", res);
-        console.log("witness", witness);
-        assert.ok(res.every((v, i)=> v == witness[i]));
+        var a0_buffer = [...utils.intToLEBuffer(a[0], 8)];
+        var a0_bits = utils.buffer2bits(a0_buffer);
+
+        var a1_buffer = [...utils.intToLEBuffer(a[1], 8)];
+        var a1_bits = utils.buffer2bits(a1_buffer);
+
+        var b0_buffer = [...utils.intToLEBuffer(b[0], 8)];
+        var b0_bits = utils.buffer2bits(b0_buffer);
+
+        var b1_buffer = [...utils.intToLEBuffer(b[1], 8)];
+        var b1_bits = utils.buffer2bits(b1_buffer);
+
+        var res_buffer = [];
+        for(let i=0; i<res.length; i++)
+        {
+            res_buffer.push(...utils.intToLEBuffer(res[i], 8));
+        }
+        var res_bits = utils.buffer2bits(res_buffer);
+
+        let witness = await cir.calculateWitness({"a": [a0_bits,a1_bits], "b": [b0_bits, b1_bits]});
+        witness = witness.slice(1, 129);
+        assert.ok(res_bits.every((v, i)=> v == witness[i]));
     });
 });

--- a/test/mul.test.js
+++ b/test/mul.test.js
@@ -2,7 +2,7 @@ const path = require("path");
 const assert = require("assert");
 const wasmTester = require("circom_tester").wasm;
 const Module = require("./module.js");
-
+const utils = require("./utils");
 
 describe("Mul test", () => {
     it("Show do mul correctly", async() => {
@@ -19,10 +19,21 @@ describe("Mul test", () => {
             res.push(BigInt(Module.HEAPU64[dst/BigInt64Array.BYTES_PER_ELEMENT+i]));
         }
 
-        let witness = await cir.calculateWitness({src1: a, src2: b});
-        witness = witness.slice(1,3);
-        console.log("Expected", res);    
-        console.log("witness", witness);
-        assert.ok(res.every((v, i)=> v == witness[i]));
+        var a_buffer = [...utils.intToLEBuffer(a, 8)];
+        var a_bits = utils.buffer2bits(a_buffer);
+
+        var b_buffer = [...utils.intToLEBuffer(b, 8)];
+        var b_bits = utils.buffer2bits(b_buffer);
+
+        var res_buffer = [];
+        for(let i=0; i<res.length; i++)
+        {
+            res_buffer.push(...utils.intToLEBuffer(res[i], 8));
+        }
+        var res_bits = utils.buffer2bits(res_buffer);
+
+        let witness = await cir.calculateWitness({src1: a_bits, src2: b_bits});
+        witness = witness.slice(1,129);
+        assert.ok(res_bits.every((v, i)=> v == witness[i]));
     });
 });

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,0 +1,30 @@
+function buffer2bits(buff) {
+	const res = [];
+	for (let i = 0; i < buff.length; i++) {
+		for (let j = 0; j < 8; j++) {
+			if ((buff[i] >> 7-j) & 1) {
+				res.push(1n);
+			} else {
+				res.push(0n);
+			}
+		}
+	}
+	return res;
+}
+
+function convertToLength(hexInput, len) {
+	while (hexInput.length  != len) {
+		hexInput = '0' + hexInput;
+	}
+	return hexInput;
+}
+
+function intToLEBuffer(x, bufSize) {
+	return Buffer.from(convertToLength(x.toString(16), bufSize*2), 'hex').reverse()
+}
+
+module.exports = {
+    buffer2bits,
+    convertToLength,
+    intToLEBuffer
+};


### PR DESCRIPTION
1. Makes the whole circuit consistent with the input scheme as used in circomlib.
2. Removes SHA256 public inputs from gcm_siv_enc_2_keys circuit.
3. Marginally reduces number of non-linear constraints.